### PR TITLE
Rework/fix implementation of AND predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,3 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/bep/predicate)](https://goreportcard.com/report/github.com/bep/predicate)
 [![GoDoc](https://godoc.org/github.com/bep/predicate?status.svg)](https://godoc.org/github.com/bep/predicate)
 
-
-```go
-var (
-   pHello predicate.P[string] = func(s string) bool {
-      return s == "hello"
-   }
-   pWorld predicate.P[string] = func(s string) bool {
-      return s == "world"
-   }
-   pAny predicate.P[string] = func(s string) bool {
-      return s != ""
-   }
-)
-
-fmt.Println("Or (true):", pHello.Or(pWorld)("hello"))
-fmt.Println("Or (false):", pHello.Or(pWorld)("foo"))
-fmt.Println("And (false):", pHello.And(pWorld)("hello"))
-fmt.Println("And (true):", pHello.And(pAny)("hello"))
-fmt.Println("Negate (false):", pHello.Negate()("hello"))
-fmt.Println("Negate (true):", pHello.Negate()("world"))
-fmt.Println("Chained (true):", pHello.And(pAny.Or(pWorld))("hello"))
-fmt.Println("Chained (false):", pHello.And(pAny.Or(pWorld))("foo"))
-```


### PR DESCRIPTION
My test cases for this left something to be desired. The AND predicate didn't behave correctly in nested scenarios. This commit fixes that.

I have kept the predicate as a func type, but it now returns a Match interface, which allows us to detect if we need to break the chain of predicates.

```
BenchmarkPredicate/and_or_no_match-10           176103381                6.794 ns/op           0 B/op          0 allocs/op
BenchmarkPredicate/and_and_no_match-10          286360015                4.177 ns/op           0 B/op          0 allocs/op
BenchmarkPredicate/and_and_match-10             155906619                7.820 ns/op           0 B/op          0 allocs/op
```
