### PR TITLE
Add missing godoc comments for public symbols

### DIFF
--- a/predicate.go
+++ b/predicate.go
@@ -5,6 +5,7 @@ package predicate
 
 // Match represents the result of a predicate evaluation.
 type Match interface {
+	// OK returns true if the predicate matched.
 	OK() bool
 }
 
@@ -17,6 +18,7 @@ var (
 // BoolMatch is a simple Match implementation based on a boolean value.
 type BoolMatch bool
 
+// OK returns the underlying boolean value.
 func (b BoolMatch) OK() bool {
 	return bool(b)
 }


### PR DESCRIPTION
## Summary
- Add godoc comment for `Match.OK()` interface method
- Add godoc comment for `BoolMatch.OK()` method

These comments ensure all public symbols are properly documented.

## Test plan
- [x] Existing tests pass
- [x] No functional changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)